### PR TITLE
2D rot shift convenience layer

### DIFF
--- a/src/torch_transform_image/__init__.py
+++ b/src/torch_transform_image/__init__.py
@@ -9,10 +9,13 @@ except PackageNotFoundError:
 __author__ = "Alister Burt"
 __email__ = "alisterburt@gmail.com"
 
-from torch_transform_image.transforms_2d import affine_transform_image_2d
+from torch_transform_image.transforms_2d import (
+    affine_transform_image_2d,
+    shift_rotate_image_2d,
+)
 from torch_transform_image.transforms_3d import affine_transform_image_3d
 
 __all__ = [
-    'affine_transform_image_2d',
-    'affine_transform_image_3d',
+    "affine_transform_image_2d",
+    "affine_transform_image_3d",
 ]

--- a/src/torch_transform_image/__init__.py
+++ b/src/torch_transform_image/__init__.py
@@ -9,13 +9,10 @@ except PackageNotFoundError:
 __author__ = "Alister Burt"
 __email__ = "alisterburt@gmail.com"
 
-from torch_transform_image.transforms_2d import (
-    affine_transform_image_2d,
-    shift_rotate_image_2d,
-)
+from torch_transform_image.transforms_2d import affine_transform_image_2d, shift_rotate_image_2d
 from torch_transform_image.transforms_3d import affine_transform_image_3d
 
 __all__ = [
-    "affine_transform_image_2d",
-    "affine_transform_image_3d",
+    'affine_transform_image_2d',
+    'affine_transform_image_3d',
 ]

--- a/src/torch_transform_image/__init__.py
+++ b/src/torch_transform_image/__init__.py
@@ -15,4 +15,5 @@ from torch_transform_image.transforms_3d import affine_transform_image_3d
 __all__ = [
     'affine_transform_image_2d',
     'affine_transform_image_3d',
+    'shift_rotate_image_2d',
 ]

--- a/src/torch_transform_image/__init__.py
+++ b/src/torch_transform_image/__init__.py
@@ -9,11 +9,11 @@ except PackageNotFoundError:
 __author__ = "Alister Burt"
 __email__ = "alisterburt@gmail.com"
 
-from torch_transform_image.transforms_2d import affine_transform_image_2d, shift_rotate_image_2d
+from torch_transform_image.transforms_2d import affine_transform_image_2d, rotate_shift_image_2d
 from torch_transform_image.transforms_3d import affine_transform_image_3d
 
 __all__ = [
     'affine_transform_image_2d',
     'affine_transform_image_3d',
-    'shift_rotate_image_2d',
+    'rotate_shift_image_2d',
 ]

--- a/src/torch_transform_image/__init__.py
+++ b/src/torch_transform_image/__init__.py
@@ -9,11 +9,12 @@ except PackageNotFoundError:
 __author__ = "Alister Burt"
 __email__ = "alisterburt@gmail.com"
 
-from torch_transform_image.transforms_2d import affine_transform_image_2d, rotate_shift_image_2d
+from torch_transform_image.transforms_2d import affine_transform_image_2d, rotate_then_shift_image_2d, shift_then_rotate_image_2d
 from torch_transform_image.transforms_3d import affine_transform_image_3d
 
 __all__ = [
     'affine_transform_image_2d',
+    'rotate_then_shift_image_2d',
+    'shift_then_rotate_image_2d',
     'affine_transform_image_3d',
-    'rotate_shift_image_2d',
 ]

--- a/src/torch_transform_image/transforms_2d.py
+++ b/src/torch_transform_image/transforms_2d.py
@@ -3,23 +3,22 @@ from typing import Literal
 import einops
 import torch
 from torch_affine_utils import homogenise_coordinates
+from torch_affine_utils.transforms_2d import R, T
 from torch_grid_utils import coordinate_grid
 from torch_image_interpolation import sample_image_2d
 
 
 def affine_transform_image_2d(
-        image: torch.Tensor,
-        matrices: torch.Tensor,
-        interpolation: Literal['nearest', 'bilinear', 'bicubic'],
-        yx_matrices: bool = False,
+    image: torch.Tensor,
+    matrices: torch.Tensor,
+    interpolation: Literal["nearest", "bilinear", "bicubic"],
+    yx_matrices: bool = False,
 ) -> torch.Tensor:
     # grab image dimensions
     h, w = image.shape[-2:]
 
     if not yx_matrices:
-        matrices[..., :2, :2] = (
-            torch.flip(matrices[..., :2, :2], dims=(-2, -1))
-        )
+        matrices[..., :2, :2] = torch.flip(matrices[..., :2, :2], dims=(-2, -1))
         matrices[..., :2, 2] = torch.flip(matrices[..., :2, 2], dims=(-1,))
 
     # generate grid of pixel coordinates
@@ -27,10 +26,33 @@ def affine_transform_image_2d(
 
     # apply matrix to coordinates
     grid = homogenise_coordinates(grid)  # (h, w, yxw)
-    grid = einops.rearrange(grid, 'h w yxw -> h w yxw 1')
+    grid = einops.rearrange(grid, "h w yxw -> h w yxw 1")
     grid = matrices @ grid
-    grid = grid[..., :2, 0]  # dehomogenise coordinates: (..., h, w, yxw, 1) -> (..., h, w, yx)
+    grid = grid[
+        ..., :2, 0
+    ]  # dehomogenise coordinates: (..., h, w, yxw, 1) -> (..., h, w, yx)
 
     # sample image at transformed positions
     result = sample_image_2d(image, coordinates=grid, interpolation=interpolation)
     return result
+
+
+def shift_rotate_image_2d(
+    image: torch.Tensor,
+    angles: torch.Tensor | list[int | float] | int | float = 0,
+    shifts: torch.Tensor | list[int | float] | int | float = 0,
+    interpolation_mode: Literal["nearest", "bilinear", "bicubic"] = "bicubic",
+    rotate_first: bool = True,
+) -> torch.Tensor:
+    """This is a wrapper function to simplify 2D rotation."""
+    angle_tensor = torch.as_tensor(angles, device=image.device, dtype=torch.float32)
+    shift_tensor = torch.as_tensor(shifts, device=image.device, dtype=torch.float32)
+    if rotate_first:
+        matrices = T(shift_tensor) @ R(angle_tensor)
+    else:
+        matrices = R(angle_tensor) @ T(shift_tensor)
+    return affine_transform_image_2d(
+        image=image,
+        matrices=matrices,
+        interpolation=interpolation_mode,
+    )

--- a/src/torch_transform_image/transforms_2d.py
+++ b/src/torch_transform_image/transforms_2d.py
@@ -44,21 +44,27 @@ def affine_transform_image_2d(
 
 def shift_rotate_image_2d(
     image: torch.Tensor,
-    angles: torch.Tensor | list[int | float] | int | float = 0,
-    shifts: torch.Tensor | list[int | float] | int | float = 0,
+    angle: torch.Tensor | int | float = 0,
+    shift: torch.Tensor | list[float | int] | int = 0,
     interpolation_mode: Literal["nearest", "bilinear", "bicubic"] = "bicubic",
     rotate_first: bool = True,
 ) -> torch.Tensor:
     """This is a wrapper function to simplify 2D rotation."""
     image_center = None
-    if angles:
+    if angle:
         h, w = image.shape[-2:]
         image_center = dft_center(
             image_shape=(h, w), device=image.device, fftshift=True, rfft=False
-        )
+            )
 
-    angle_tensor = torch.as_tensor(angles, device=image.device, dtype=torch.float32)
-    shift_tensor = torch.as_tensor(shifts, device=image.device, dtype=torch.float32)
+    angle_tensor = torch.as_tensor(angle, device=image.device, dtype=torch.float32)
+    shift_tensor = torch.as_tensor(shift, device=image.device, dtype=torch.float32)
+
+    if angle_tensor.numel() > 1 or shift_tensor.numel() > 2:
+        raise NotImplementedError(
+            "Only single angle and single shift values are supported."
+            )
+
     if rotate_first:
         matrices = T(shift_tensor) @ R(angle_tensor)
     else:

--- a/src/torch_transform_image/transforms_2d.py
+++ b/src/torch_transform_image/transforms_2d.py
@@ -50,9 +50,9 @@ def rotate_shift_image_2d(
 ) -> torch.Tensor:
     """This is a wrapper function for easy 2D shifts and rotations.
 
-    Rotations are specified in degrees and performed CCW around the
-    center of the image. Shifts are specified in number of pixels and
-    shift up/right with the origin in the lower left. Currently, only a
+    The image is rotated CCW around its center by the specified number
+    of degrees and shifted up/left by the specified number of pixels
+    (see note about direction conventions below!). Currently, only a
     single shift and a single rotation are allowed.
 
     Parameters
@@ -76,6 +76,14 @@ def rotate_shift_image_2d(
     -------
     torch.Tensor
         The shifted and/or rotated image.
+
+    Notes
+    -----
+    The description of operations assumes the origin (0,0) of the image
+    is in the lower left (following convention in cryo-EM image
+    processing). This is NOT the default for images displayed by
+    matplotlib, plotly, etc. so images may be tranformed in the opposite
+    direction from expected.
     """
     image_center = 0
     if rotate:

--- a/src/torch_transform_image/transforms_2d.py
+++ b/src/torch_transform_image/transforms_2d.py
@@ -9,16 +9,18 @@ from torch_image_interpolation import sample_image_2d
 
 
 def affine_transform_image_2d(
-    image: torch.Tensor,
-    matrices: torch.Tensor,
-    interpolation: Literal["nearest", "bilinear", "bicubic"],
-    yx_matrices: bool = False,
+        image: torch.Tensor,
+        matrices: torch.Tensor,
+        interpolation: Literal['nearest', 'bilinear', 'bicubic'],
+        yx_matrices: bool = False,
 ) -> torch.Tensor:
     # grab image dimensions
     h, w = image.shape[-2:]
 
     if not yx_matrices:
-        matrices[..., :2, :2] = torch.flip(matrices[..., :2, :2], dims=(-2, -1))
+        matrices[..., :2, :2] = (
+            torch.flip(matrices[..., :2, :2], dims=(-2, -1))
+        )
         matrices[..., :2, 2] = torch.flip(matrices[..., :2, 2], dims=(-1,))
 
     # generate grid of pixel coordinates
@@ -26,11 +28,9 @@ def affine_transform_image_2d(
 
     # apply matrix to coordinates
     grid = homogenise_coordinates(grid)  # (h, w, yxw)
-    grid = einops.rearrange(grid, "h w yxw -> h w yxw 1")
+    grid = einops.rearrange(grid, 'h w yxw -> h w yxw 1')
     grid = matrices @ grid
-    grid = grid[
-        ..., :2, 0
-    ]  # dehomogenise coordinates: (..., h, w, yxw, 1) -> (..., h, w, yx)
+    grid = grid[..., :2, 0]  # dehomogenise coordinates: (..., h, w, yxw, 1) -> (..., h, w, yx)
 
     # sample image at transformed positions
     result = sample_image_2d(image, coordinates=grid, interpolation=interpolation)

--- a/src/torch_transform_image/transforms_2d.py
+++ b/src/torch_transform_image/transforms_2d.py
@@ -66,9 +66,9 @@ def shift_rotate_image_2d(
             )
 
     if rotate_first:
-        matrices = T(shift_tensor) @ R(angle_tensor)
-    else:
         matrices = R(angle_tensor) @ T(shift_tensor)
+    else:
+        matrices = T(shift_tensor) @ R(angle_tensor)
     return affine_transform_image_2d(
         image=image,
         matrices=matrices,

--- a/src/torch_transform_image/transforms_2d.py
+++ b/src/torch_transform_image/transforms_2d.py
@@ -55,4 +55,5 @@ def shift_rotate_image_2d(
         image=image,
         matrices=matrices,
         interpolation=interpolation_mode,
+        yx_matrices=True,
     )

--- a/src/torch_transform_image/transforms_2d.py
+++ b/src/torch_transform_image/transforms_2d.py
@@ -43,7 +43,7 @@ def affine_transform_image_2d(
 
 def rotate_shift_image_2d(
     image: torch.Tensor,
-    angle: int | float = 0,
+    rotate: int | float = 0,
     shift: list[float | int] | tuple[float | int, float | int] = (0, 0),
     interpolation: Literal["nearest", "bilinear", "bicubic"] = "bicubic",
     rotate_first: bool = True,
@@ -78,19 +78,19 @@ def rotate_shift_image_2d(
         The shifted and/or rotated image.
     """
     image_center = 0
-    if angle:
+    if rotate:
         h, w = image.shape[-2:]
         image_center = dft_center(
             image_shape=(h, w), device=image.device, fftshift=True, rfft=False
             )
 
     center_tensor = torch.as_tensor(image_center, device=image.device, dtype=torch.float32)
-    angle_tensor = torch.as_tensor(angle, device=image.device, dtype=torch.float32)
+    rotate_tensor = torch.as_tensor(rotate, device=image.device, dtype=torch.float32)
     # Because shift is applied to the coordinate grid, it must be
     # negated to produce a positive (up/right) shift on the image.
     shift_tensor = -torch.as_tensor(shift, device=image.device, dtype=torch.float32)
 
-    if angle_tensor.numel() > 1 or shift_tensor.numel() > 2:
+    if rotate_tensor.numel() > 1 or shift_tensor.numel() > 2:
         raise NotImplementedError(
             "Only single angle and single shift values are supported."
             )
@@ -98,7 +98,7 @@ def rotate_shift_image_2d(
     if rotate_first:
         matrix = (
             T(center_tensor) @
-            R(angle_tensor) @
+            R(rotate_tensor) @
             T(shift_tensor) @
             T(-center_tensor)
         )
@@ -106,7 +106,7 @@ def rotate_shift_image_2d(
         matrix = (
             T(center_tensor) @
             T(shift_tensor) @
-            R(angle_tensor) @
+            R(rotate_tensor) @
             T(-center_tensor)
         )
 

--- a/src/torch_transform_image/transforms_2d.py
+++ b/src/torch_transform_image/transforms_2d.py
@@ -51,9 +51,9 @@ def rotate_shift_image_2d(
     """This is a wrapper function for easy 2D shifts and rotations.
 
     Rotations are specified in degrees and performed CCW around the
-    center of the image. Rotating and shifting can be performed in
-    either order. Currently, only a single shift and a single rotation
-    are allowed.
+    center of the image. Shifts are specified in number of pixels and
+    shift up/right with the origin in the lower left. Currently, only a
+    single shift and a single rotation are allowed.
 
     Parameters
     ----------
@@ -63,8 +63,9 @@ def rotate_shift_image_2d(
         The angle in degrees by which to rotate the image.
     shift : list[float | int] | tuple[float | int, float | int],
     optional
-        The number of pixels by which to shift the image. Must be a list
-        or tuple of length 2 in the form (y, x).
+        The number of pixels by which to shift the image. Positive
+        values shift up/right. Must be a list or tuple of length 2 in
+        the form (y, x).
     interpolation : Literal["nearest", "bilinear", "bicubic"], optional
         The interpolation method to use. Default is "bicubic".
     rotate_first : bool, optional
@@ -85,7 +86,9 @@ def rotate_shift_image_2d(
 
     center_tensor = torch.as_tensor(image_center, device=image.device, dtype=torch.float32)
     angle_tensor = torch.as_tensor(angle, device=image.device, dtype=torch.float32)
-    shift_tensor = torch.as_tensor(shift, device=image.device, dtype=torch.float32)
+    # Because shift is applied to the coordinate grid, it must be
+    # negated to produce a positive (up/right) shift on the image.
+    shift_tensor = -torch.as_tensor(shift, device=image.device, dtype=torch.float32)
 
     if angle_tensor.numel() > 1 or shift_tensor.numel() > 2:
         raise NotImplementedError(

--- a/src/torch_transform_image/transforms_2d.py
+++ b/src/torch_transform_image/transforms_2d.py
@@ -41,7 +41,7 @@ def affine_transform_image_2d(
     return result
 
 
-def shift_rotate_image_2d(  # TODO: rename to rotate_shift_image_2d to match default order
+def rotate_shift_image_2d(
     image: torch.Tensor,
     angle: torch.Tensor | int | float = 0,
     shift: torch.Tensor | list[float | int] | int = 0,

--- a/src/torch_transform_image/transforms_2d.py
+++ b/src/torch_transform_image/transforms_2d.py
@@ -43,12 +43,39 @@ def affine_transform_image_2d(
 
 def rotate_shift_image_2d(
     image: torch.Tensor,
-    angle: torch.Tensor | int | float = 0,
-    shift: torch.Tensor | list[float | int] | int = 0,
-    interpolation_mode: Literal["nearest", "bilinear", "bicubic"] = "bicubic",  # TODO: rename to interpolation to match
+    angle: int | float = 0,
+    shift: list[float | int] | tuple[float | int, float | int] = (0, 0),
+    interpolation: Literal["nearest", "bilinear", "bicubic"] = "bicubic",
     rotate_first: bool = True,
 ) -> torch.Tensor:
-    """This is a wrapper function to simplify 2D rotation."""  # TODO: add longer docstring
+    """This is a wrapper function for easy 2D shifts and rotations.
+
+    Rotations are specified in degrees and performed CCW around the
+    center of the image. Rotating and shifting can be performed in
+    either order. Currently, only a single shift and a single rotation
+    are allowed.
+
+    Parameters
+    ----------
+    image : torch.Tensor
+        The image to be shifted/rotated.
+    angle : int | float, optional
+        The angle in degrees by which to rotate the image.
+    shift : list[float | int] | tuple[float | int, float | int],
+    optional
+        The number of pixels by which to shift the image. Must be a list
+        or tuple of length 2 in the form (y, x).
+    interpolation : Literal["nearest", "bilinear", "bicubic"], optional
+        The interpolation method to use. Default is "bicubic".
+    rotate_first : bool, optional
+        If True, the image is rotated first and then shifted. If False,
+        the image is shifted first and then rotated. Default is True.
+
+    Returns
+    -------
+    torch.Tensor
+        The shifted and/or rotated image.
+    """
     image_center = 0
     if angle:
         h, w = image.shape[-2:]
@@ -57,7 +84,6 @@ def rotate_shift_image_2d(
             )
 
     center_tensor = torch.as_tensor(image_center, device=image.device, dtype=torch.float32)
-    inv_center_tensor = torch.as_tensor(-center_tensor, device=image.device, dtype=torch.float32)
     angle_tensor = torch.as_tensor(angle, device=image.device, dtype=torch.float32)
     shift_tensor = torch.as_tensor(shift, device=image.device, dtype=torch.float32)
 
@@ -71,19 +97,19 @@ def rotate_shift_image_2d(
             T(center_tensor) @
             R(angle_tensor) @
             T(shift_tensor) @
-            T(inv_center_tensor)
+            T(-center_tensor)
         )
     else:
         matrix = (
             T(center_tensor) @
             T(shift_tensor) @
             R(angle_tensor) @
-            T(inv_center_tensor)
+            T(-center_tensor)
         )
 
     return affine_transform_image_2d(
         image=image,
         matrices=matrix,
-        interpolation=interpolation_mode,
+        interpolation=interpolation,
         yx_matrices=True,
     )

--- a/tests/test_torch_image_transform.py
+++ b/tests/test_torch_image_transform.py
@@ -59,17 +59,17 @@ def test_affine_transform_image_3d():
 
 def test_shift_rotate_image_2d():
     image = torch.zeros((28, 28), dtype=torch.float32)
-    image[18, 14] = 1
+    image[16, 14] = 1
     image = image.float()
 
     result = shift_rotate_image_2d(
         image=image,
-        angles=90,
-        shifts=[4, 0],
+        angles=180,
+        shifts=[-2, 0],
         interpolation_mode="bicubic",
         rotate_first=True,
     )
 
-    assert image[14, 14] == 0
-    assert result[14, 14] == 1
+    assert image[10, 14] == 0
+    assert result[10, 14] == 1
     assert result[18, 14] == 0

--- a/tests/test_torch_image_transform.py
+++ b/tests/test_torch_image_transform.py
@@ -18,12 +18,7 @@ def test_affine_transform_image_2d():
     M = T_2d([4, 0])  # move coordinates up 4 in h dim
 
     # sample
-    result = affine_transform_image_2d(
-        image,
-        M,
-        interpolation="bicubic",
-        yx_matrices=True,
-    )
+    result = affine_transform_image_2d(image, M, interpolation='bicubic', yx_matrices=True)
 
     # sanity check, array center which was 4 voxels below the dot should now be 1
     assert result.shape == image.shape
@@ -44,12 +39,7 @@ def test_affine_transform_image_3d():
     M = T_3d([4, 0, 0])  # move coordinates up 4 in d dim
 
     # sample
-    result = affine_transform_image_3d(
-        image,
-        M,
-        interpolation="trilinear",
-        zyx_matrices=True,
-    )
+    result = affine_transform_image_3d(image, M, interpolation='trilinear', zyx_matrices=True)
 
     # sanity check, array center which was 4 voxels below the dot should now be 1
     assert result.shape == image.shape

--- a/tests/test_torch_image_transform.py
+++ b/tests/test_torch_image_transform.py
@@ -1,6 +1,6 @@
 import torch
 from torch_transform_image import affine_transform_image_2d, affine_transform_image_3d
-from torch_transform_image import rotate_shift_image_2d
+from torch_transform_image import rotate_then_shift_image_2d, shift_then_rotate_image_2d
 from torch_affine_utils.transforms_2d import T as T_2d, S as S_2d
 from torch_affine_utils.transforms_3d import T as T_3d, S as S_3d
 
@@ -77,17 +77,34 @@ def test_rotate_shift_image_2d():
     image[18, 14] = 1
     image = image.float()
 
-    result = rotate_shift_image_2d(
+    result = rotate_then_shift_image_2d(
         image=image,
         rotate=90,
         shift=[2, 0],
         interpolation="bicubic",
-        rotate_first=True,
     )
 
     # sanity check, array center which was 4 voxels below the dot should now be 1
     assert image[12, 12] == 0
-    assert result[12, 10] == 1
+    assert result[16, 10] == 1
+    assert result[18, 14] == 0
+
+
+def test_shift_rotate_image_2d():
+    image = torch.zeros((28, 28), dtype=torch.float32)
+    image[18, 14] = 1
+    image = image.float()
+
+    result = shift_then_rotate_image_2d(
+        image=image,
+        rotate=90,
+        shift=[2, 0],
+        interpolation="bicubic",
+    )
+
+    # sanity check, array center which was 4 voxels below the dot should now be 1
+    assert image[12, 12] == 0
+    assert result[14, 8] == 1
     assert result[18, 14] == 0
 
 

--- a/tests/test_torch_image_transform.py
+++ b/tests/test_torch_image_transform.py
@@ -1,6 +1,6 @@
 import torch
 from torch_transform_image import affine_transform_image_2d, affine_transform_image_3d
-from torch_transform_image import shift_rotate_image_2d
+from torch_transform_image import rotate_shift_image_2d
 from torch_affine_utils.transforms_2d import T as T_2d, S as S_2d
 from torch_affine_utils.transforms_3d import T as T_3d, S as S_3d
 
@@ -72,12 +72,12 @@ def test_affine_transform_image_3d():
     assert result[18, 14, 14] == 0
 
 
-def test_shift_rotate_image_2d():
+def test_rotate_shift_image_2d():
     image = torch.zeros((28, 28), dtype=torch.float32)
     image[18, 14] = 1
     image = image.float()
 
-    result = shift_rotate_image_2d(
+    result = rotate_shift_image_2d(
         image=image,
         angle=90,
         shift=[2, 0],

--- a/tests/test_torch_image_transform.py
+++ b/tests/test_torch_image_transform.py
@@ -81,7 +81,7 @@ def test_rotate_shift_image_2d():
         image=image,
         angle=90,
         shift=[2, 0],
-        interpolation_mode="bicubic",
+        interpolation="bicubic",
         rotate_first=True,
     )
 

--- a/tests/test_torch_image_transform.py
+++ b/tests/test_torch_image_transform.py
@@ -18,7 +18,9 @@ def test_affine_transform_image_2d():
     M = T_2d([4, 0])  # move coordinates up 4 in h dim
 
     # sample
-    result = affine_transform_image_2d(image, M, interpolation='bicubic', yx_matrices=True)
+    result = affine_transform_image_2d(
+        image, M, interpolation='bicubic', yx_matrices=True
+        )
 
     # sanity check, array center which was 4 voxels below the dot should now be 1
     assert result.shape == image.shape
@@ -39,7 +41,9 @@ def test_affine_transform_image_3d():
     M = T_3d([4, 0, 0])  # move coordinates up 4 in d dim
 
     # sample
-    result = affine_transform_image_3d(image, M, interpolation='trilinear', zyx_matrices=True)
+    result = affine_transform_image_3d(
+        image, M, interpolation='trilinear', zyx_matrices=True
+        )
 
     # sanity check, array center which was 4 voxels below the dot should now be 1
     assert result.shape == image.shape

--- a/tests/test_torch_image_transform.py
+++ b/tests/test_torch_image_transform.py
@@ -79,7 +79,7 @@ def test_rotate_shift_image_2d():
 
     result = rotate_shift_image_2d(
         image=image,
-        angle=90,
+        rotate=90,
         shift=[2, 0],
         interpolation="bicubic",
         rotate_first=True,

--- a/tests/test_torch_image_transform.py
+++ b/tests/test_torch_image_transform.py
@@ -19,8 +19,8 @@ def test_affine_transform_image_2d():
 
     # sample
     result = affine_transform_image_2d(
-        image, M, interpolation='bicubic', yx_matrices=True
-        )
+        image, M, interpolation='bicubic', yx_matrices=True,
+    )
 
     # sanity check, array center which was 4 voxels below the dot should now be 1
     assert result.shape == image.shape
@@ -42,8 +42,8 @@ def test_affine_transform_image_3d():
 
     # sample
     result = affine_transform_image_3d(
-        image, M, interpolation='trilinear', zyx_matrices=True
-        )
+        image, M, interpolation='trilinear', zyx_matrices=True,
+    )
 
     # sanity check, array center which was 4 voxels below the dot should now be 1
     assert result.shape == image.shape

--- a/tests/test_torch_image_transform.py
+++ b/tests/test_torch_image_transform.py
@@ -74,22 +74,23 @@ def test_affine_transform_image_3d():
 
 def test_shift_rotate_image_2d():
     image = torch.zeros((28, 28), dtype=torch.float32)
-    image[16, 14] = 1
+    image[18, 14] = 1
     image = image.float()
 
     result = shift_rotate_image_2d(
         image=image,
-        angle=180,
-        shift=[-2, 0],
+        angle=90,
+        shift=[2, 0],
         interpolation_mode="bicubic",
         rotate_first=True,
     )
 
-    assert image[10, 14] == 0
-    assert result[10, 14] == 1
+    # sanity check, array center which was 4 voxels below the dot should now be 1
+    assert image[12, 12] == 0
+    assert result[12, 10] == 1
     assert result[18, 14] == 0
 
-    
+
 def test_affine_transform_image_3d_scaling():
     # set up test image with dot at (18, 14)
     image = torch.zeros((28, 28, 28), dtype=torch.float32)
@@ -109,4 +110,3 @@ def test_affine_transform_image_3d_scaling():
     assert result.shape == (56,56,56)
     assert result[36, 28, 28] == 1
     assert result[18, 14, 14] == 0
-

--- a/tests/test_torch_image_transform.py
+++ b/tests/test_torch_image_transform.py
@@ -64,8 +64,8 @@ def test_shift_rotate_image_2d():
 
     result = shift_rotate_image_2d(
         image=image,
-        angles=180,
-        shifts=[-2, 0],
+        angle=180,
+        shift=[-2, 0],
         interpolation_mode="bicubic",
         rotate_first=True,
     )

--- a/tests/test_torch_image_transform.py
+++ b/tests/test_torch_image_transform.py
@@ -1,5 +1,6 @@
 import torch
 from torch_transform_image import affine_transform_image_2d, affine_transform_image_3d
+from torch_transform_image import shift_rotate_image_2d
 from torch_affine_utils.transforms_2d import T as T_2d
 from torch_affine_utils.transforms_3d import T as T_3d
 
@@ -18,7 +19,10 @@ def test_affine_transform_image_2d():
 
     # sample
     result = affine_transform_image_2d(
-        image, M, interpolation='bicubic', yx_matrices=True,
+        image,
+        M,
+        interpolation="bicubic",
+        yx_matrices=True,
     )
 
     # sanity check, array center which was 4 voxels below the dot should now be 1
@@ -41,10 +45,31 @@ def test_affine_transform_image_3d():
 
     # sample
     result = affine_transform_image_3d(
-        image, M, interpolation='trilinear', zyx_matrices=True,
+        image,
+        M,
+        interpolation="trilinear",
+        zyx_matrices=True,
     )
 
     # sanity check, array center which was 4 voxels below the dot should now be 1
     assert result.shape == image.shape
     assert result[14, 14, 14] == 1
     assert result[18, 14, 14] == 0
+
+
+def test_shift_rotate_image_2d():
+    image = torch.zeros((28, 28), dtype=torch.float32)
+    image[18, 14] = 1
+    image = image.float()
+
+    result = shift_rotate_image_2d(
+        image=image,
+        angles=90,
+        shifts=[4, 0],
+        interpolation_mode="bicubic",
+        rotate_first=True,
+    )
+
+    assert image[14, 14] == 0
+    assert result[14, 14] == 1
+    assert result[18, 14] == 0


### PR DESCRIPTION
This adds a wrapper function for easier rotation and shifting of 2D images. It required minimal editing of `affine_transform_image_2d()`. Currently, only single rotation and shift values are supported and only for 2D images. I'd like to add support for multiple transformations and for volumes in the future. Feedback welcome!