### PR TITLE
3D convenience layer!

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,7 @@ docs/_build/
 target/
 
 # Jupyter Notebook
+*dev.ipynb
 .ipynb_checkpoints
 
 # pyenv

--- a/src/torch_transform_image/__init__.py
+++ b/src/torch_transform_image/__init__.py
@@ -10,7 +10,7 @@ __author__ = "Alister Burt"
 __email__ = "alisterburt@gmail.com"
 
 from torch_transform_image.transforms_2d import affine_transform_image_2d, rotate_then_shift_image_2d, shift_then_rotate_image_2d
-from torch_transform_image.transforms_3d import affine_transform_image_3d
+from torch_transform_image.transforms_3d import affine_transform_image_3d, rotate_then_shift_image_3d, shift_then_rotate_image_3d
 
 __all__ = [
     'affine_transform_image_2d',

--- a/src/torch_transform_image/__init__.py
+++ b/src/torch_transform_image/__init__.py
@@ -17,4 +17,6 @@ __all__ = [
     'rotate_then_shift_image_2d',
     'shift_then_rotate_image_2d',
     'affine_transform_image_3d',
+    'rotate_then_shift_image_3d',
+    'shift_then_rotate_image_3d',
 ]

--- a/src/torch_transform_image/transforms_3d.py
+++ b/src/torch_transform_image/transforms_3d.py
@@ -60,7 +60,9 @@ def rotate_then_shift_image_3d(
     rotate_zyx : list[float] | tuple[float, float, float], optional
         The angles in degrees by which to rotate the image according to
         the right hand rule. Positive values rotate the image CCW. Must
-        be a list or tuple of length 3 in the order (z, y, x).
+        be a list or tuple of length 3 in the order (z, y, x). If
+        multiple angles are provided, rotations will be performed in z,
+        y, x order.
     shifts_zyx : list[float] | tuple[float, float, float], optional
         The number of pixels by which to shift the image. Positive
         values shift up/right. Must be a list or tuple of length 3 in
@@ -75,8 +77,7 @@ def rotate_then_shift_image_3d(
 
     See Also
     --------
-    shift_then_rotate_image_3d
-    transforms_2d.rotate_then_shift_image_2d
+    shift_then_rotate_image_3d transforms_2d.rotate_then_shift_image_2d
 
     Notes
     -----
@@ -105,9 +106,9 @@ def rotate_then_shift_image_3d(
     matrix = (
         T(image_center) @
         T(shifts_zyx) @
-        Rz(rotate_zyx[0], zyx=True) @
-        Ry(rotate_zyx[1], zyx=True) @
         Rx(rotate_zyx[2], zyx=True) @
+        Ry(rotate_zyx[1], zyx=True) @
+        Rz(rotate_zyx[0], zyx=True) @
         T(-image_center)
     )
     # Matrix is inverted because it is applied to the coordinate grid,
@@ -143,7 +144,9 @@ def shift_then_rotate_image_3d(
     rotate_zyx : list[float] | tuple[float, float, float], optional
         The angles in degrees by which to rotate the image according to the
         right hand rule. Positive values rotate the image CCW. Must be a
-        list or tuple of length 3 in the order (z, y, x).
+        list or tuple of length 3 in the order (z, y, x). If
+        multiple angles are provided, rotations will be performed in z,
+        y, x order.
     shifts_zyx : list[float] | tuple[float, float, float], optional
         The number of pixels by which to shift the image. Positive values
         shift up/right. Must be a list or tuple of length 3 in the form (z,
@@ -187,9 +190,9 @@ def shift_then_rotate_image_3d(
 
     matrix = (
         T(image_center) @
-        Rz(rotate_zyx[0], zyx=True) @
-        Ry(rotate_zyx[1], zyx=True) @
         Rx(rotate_zyx[2], zyx=True) @
+        Ry(rotate_zyx[1], zyx=True) @
+        Rz(rotate_zyx[0], zyx=True) @
         T(shifts_zyx) @
         T(-image_center)
     )

--- a/src/torch_transform_image/transforms_3d.py
+++ b/src/torch_transform_image/transforms_3d.py
@@ -3,7 +3,8 @@ from typing import Literal, Optional
 import einops
 import torch
 from torch_affine_utils import homogenise_coordinates
-from torch_grid_utils import coordinate_grid
+from torch_affine_utils.transforms_3d import Rx, Ry, Rz, T
+from torch_grid_utils import coordinate_grid, dft_center
 from torch_image_interpolation import sample_image_3d
 
 
@@ -21,9 +22,7 @@ def affine_transform_image_3d(
         d, h, w = image.shape[-3:]
 
     if not zyx_matrices:
-        matrices[..., :3, :3] = (
-            torch.flip(matrices[..., :3, :3], dims=(-2, -1))
-        )
+        matrices[..., :3, :3] = torch.flip(matrices[..., :3, :3], dims=(-2, -1))
         matrices[..., :3, 3] = torch.flip(matrices[..., :3, 3], dims=(-1,))
 
     # generate grid of pixel coordinates
@@ -38,3 +37,169 @@ def affine_transform_image_3d(
     # sample image at transformed positions
     result = sample_image_3d(image, coordinates=grid, interpolation=interpolation)
     return result
+
+
+def rotate_then_shift_image_3d(
+    image: torch.Tensor,
+    rotate_zyx: list[float] | tuple[float, float, float] = (0, 0, 0),
+    shifts_zyx: list[float] | tuple[float, float, float] = (0, 0, 0),
+    interpolation: Literal["trilinear", "nearest"] = "trilinear",
+) -> torch.Tensor:
+    """
+    This is a wrapper function to easily rotate and shift a 3D image.
+
+    Image is first rotated by the specified number of degrees, according
+    to the right hand rule, around the center of the image. Then, image
+    is shifted by the specified number of pixels (see note about shift
+    conventions below).
+
+    Parameters
+    ----------
+    image : torch.Tensor
+        The image to be shifted/rotated.
+    rotate_zyx : list[float] | tuple[float, float, float], optional
+        The angles in degrees by which to rotate the image according to
+        the right hand rule. Positive values rotate the image CCW. Must
+        be a list or tuple of length 3 in the order (z, y, x).
+    shifts_zyx : list[float] | tuple[float, float, float], optional
+        The number of pixels by which to shift the image. Positive
+        values shift up/right. Must be a list or tuple of length 3 in
+        the form (z, y, x).
+    interpolation : Literal["trilinear", "nearest"], optional
+        The interpolation method to use.
+
+    Returns
+    -------
+    torch.Tensor
+        The shifted and/or rotated image.
+
+    See Also
+    --------
+    shift_then_rotate_image_3d
+    transforms_2d.rotate_then_shift_image_2d
+
+    Notes
+    -----
+    Shift direction assumes the origin (0, 0, 0) of the image is in the
+    bottom left (following convention in cryo-EM image processing).
+    Matplotlib and plotly display images with y = 0 at the top by
+    default so your image may be shifted opposite of what you expect. If
+    you want to shift the other direction, just reverse the sign of your
+    shift argument.
+
+    """
+    image_center = torch.as_tensor(0, device=image.device, dtype=torch.float32)
+    if any(rotate_zyx):
+        d, h, w = image.shape[-3:]
+        image_center = dft_center(
+            image_shape=(d, h, w), device=image.device, fftshift=True, rfft=False
+            )
+
+    if (num_angles := len(rotate_zyx)) != 3:
+        e = f"3 angles (zyx) are required but {num_angles} were supplied: {rotate_zyx}."
+        raise ValueError(e)
+    if (num_shifts := len(shifts_zyx)) != 3:
+        e = f"3 shifts (zyx) are required but {num_shifts} were supplied: {shifts_zyx}."
+        raise ValueError(e)
+
+    matrix = (
+        T(image_center) @
+        T(shifts_zyx) @
+        Rz(rotate_zyx[0], zyx=True) @
+        Ry(rotate_zyx[1], zyx=True) @
+        Rx(rotate_zyx[2], zyx=True) @
+        T(-image_center)
+    )
+    # Matrix is inverted because it is applied to the coordinate grid,
+    # not the image directly.
+    matrix = torch.inverse(matrix)
+
+    return affine_transform_image_3d(
+        image=image,
+        matrices=matrix,
+        interpolation=interpolation,
+        zyx_matrices=True,
+    )
+
+
+def shift_then_rotate_image_3d(
+    image: torch.Tensor,
+    rotate_zyx: list[float] | tuple[float, float, float] = (0, 0, 0),
+    shifts_zyx: list[float] | tuple[float, float, float] = (0, 0, 0),
+    interpolation: Literal["nearest", "trilinear"] = "trilinear",
+) -> torch.Tensor:
+    """
+    This is a wrapper function to easily shift and rotate a 3D image.
+
+    Image is first shifted by the specified number of pixels (see note
+    about shift conventions below). Then, image is rotated by the specified
+    number of degrees, according to the right hand rule, around the center
+    of the image.
+
+    Parameters
+    ----------
+    image : torch.Tensor
+        The image to be shifted/rotated.
+    rotate_zyx : list[float] | tuple[float, float, float], optional
+        The angles in degrees by which to rotate the image according to the
+        right hand rule. Positive values rotate the image CCW. Must be a
+        list or tuple of length 3 in the order (z, y, x).
+    shifts_zyx : list[float] | tuple[float, float, float], optional
+        The number of pixels by which to shift the image. Positive values
+        shift up/right. Must be a list or tuple of length 3 in the form (z,
+        y, x).
+    interpolation : Literal["trilinear", "nearest"], optional
+        The interpolation method to use.
+
+    Returns
+    -------
+    torch.Tensor
+        The shifted and/or rotated image.
+
+    See Also
+    --------
+    rotate_then_shift_image_3d
+    transforms_2d.shift_then_rotate_image_2d
+
+    Notes
+    -----
+    Shift direction assumes the origin (0, 0, 0) of the image is in the
+    bottom left (following convention in cryo-EM image processing).
+    Matplotlib and plotly display images with y = 0 at the top by default
+    so your image may be shifted opposite of what you expect. If you want
+    to shift the other direction, just reverse the sign of your shift
+    argument.
+
+    """
+    image_center = torch.as_tensor(0, device=image.device, dtype=torch.float32)
+    if any(rotate_zyx):
+        d, h, w = image.shape[-3:]
+        image_center = dft_center(
+            image_shape=(d, h, w), device=image.device, fftshift=True, rfft=False
+            )
+
+    if (num_angles := len(rotate_zyx)) != 3:
+        e = f"3 angles (zyx) are required but {num_angles} were supplied: {rotate_zyx}."
+        raise ValueError(e)
+    if (num_shifts := len(shifts_zyx)) != 3:
+        e = f"3 shifts (zyx) are required but {num_shifts} were supplied: {shifts_zyx}."
+        raise ValueError(e)
+
+    matrix = (
+        T(image_center) @
+        Rz(rotate_zyx[0], zyx=True) @
+        Ry(rotate_zyx[1], zyx=True) @
+        Rx(rotate_zyx[2], zyx=True) @
+        T(shifts_zyx) @
+        T(-image_center)
+    )
+    # Matrix is inverted because it is applied to the coordinate grid,
+    # not the image directly.
+    matrix = torch.inverse(matrix)
+
+    return affine_transform_image_3d(
+        image=image,
+        matrices=matrix,
+        interpolation=interpolation,
+        zyx_matrices=True,
+    )


### PR DESCRIPTION
Here it is! Convenience layer for 3D rotations and shifts is finished and includes tests and [examples](https://nbviewer.org/github/sjrothfuss/torch-transform-image/blob/3d-convenience-layer/examples/rotate_shift_image_3d_examples.ipynb). 

See #12 for discussion but I created a new fork for a cleaner commit history. Please let me know if you have any questions or see any issues.